### PR TITLE
fix: defined exports in package.json so the lib can be used with vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "description": "Unofficial 7TV API Wrapper.",
   "version": "0.1.2",
   "main": "lib/index.js",
+  "exports": {
+    ".": {
+      "import": "./lib/index.js"
+    }
+  },
   "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "src"
-  ],
+  "files": ["lib", "src"],
   "license": "MIT",
   "author": "sammwy",
   "scripts": {
@@ -53,11 +55,5 @@
   "bugs": {
     "url": "https://github.com/sammwyy/7tv-api/issues"
   },
-  "keywords": [
-    "7tv",
-    "7tv-client",
-    "7tv-api",
-    "twitch",
-    "twitch-emotes"
-  ]
+  "keywords": ["7tv", "7tv-client", "7tv-api", "twitch", "twitch-emotes"]
 }


### PR DESCRIPTION
I want to use this library with vite so I added an exports section in the package.json.